### PR TITLE
Cyprus accepts insular greek

### DIFF
--- a/vikingshattered/history/countries/CYP - Cyprus.txt
+++ b/vikingshattered/history/countries/CYP - Cyprus.txt
@@ -1,7 +1,7 @@
 government = monarchy
 add_government_reform = feudalism_reform
 primary_culture = cosmopolitan_french
-add_accepted_culture = greek
+add_accepted_culture = island_greek
 religion = catholic
 technology_group = western
 capital = 321	# Nicosia


### PR DESCRIPTION
Cyprus starts with accepted greek culture, but their province is insular greek and not the normal greek