### PR TITLE
Changed piety loss at ruler death

### DIFF
--- a/vikingshattered/common/defines/00_vikingshattered.lua
+++ b/vikingshattered/common/defines/00_vikingshattered.lua
@@ -1,0 +1,5 @@
+-- Format for overwriting define values:
+--
+-- NDefines.NDiplomacy.MAX_CLIENT_STATES = 20
+
+NDefines.NCountry.PIETY_PERCENTAGE_AT_NEW_RULER = 0.80 -- vanilla has 0.25


### PR DESCRIPTION
Added (and tested) new define for PIETY_PERCENTAGE_AT_NEW_RULER in defines/00_vikingshattered.lua. New define has piety loss at 80% instead of 25%.